### PR TITLE
Adjusted servo pointer declarations

### DIFF
--- a/Arduino/PlanScan/PlanScan.ino
+++ b/Arduino/PlanScan/PlanScan.ino
@@ -103,8 +103,8 @@ class RotaryEncoder {
  */
 class SensorController {
   private:
-    const Servo* horizontalServo;
-    const Servo* verticalServo;
+    Servo* horizontalServo;
+    Servo* verticalServo;
     Ultrasonic* ultrasonicA;
     Display* displayA;
     bool isReading = false;


### PR DESCRIPTION
Servo pointers were defined as const variables which limits the functions being called. This may have been the issue with the servos jittering